### PR TITLE
AB#46425: Add nil checks to prevent crash loop

### DIFF
--- a/osrm-profiles/bus-with-construction.lua
+++ b/osrm-profiles/bus-with-construction.lua
@@ -170,8 +170,10 @@ function process_node(profile, node, result, relations)
       --  check height restriction barriers
       local restricted_by_height = false
       if barrier == 'height_restrictor' then
-         local maxheight = Measure.get_max_height(node:get_value_by_key("maxheight"), node)
-         restricted_by_height = maxheight and maxheight < profile.vehicle_height
+        if maxheight and profile.vehicle_height then
+          local maxheight = Measure.get_max_height(node:get_value_by_key("maxheight"), node)
+          restricted_by_height = maxheight and maxheight < profile.vehicle_height
+        end
       end
 
       --  make an exception for rising bollard barriers

--- a/osrm-profiles/bus.lua
+++ b/osrm-profiles/bus.lua
@@ -169,8 +169,10 @@ function process_node(profile, node, result, relations)
       --  check height restriction barriers
       local restricted_by_height = false
       if barrier == 'height_restrictor' then
-         local maxheight = Measure.get_max_height(node:get_value_by_key("maxheight"), node)
-         restricted_by_height = maxheight and maxheight < profile.vehicle_height
+        if maxheight and profile.vehicle_height then
+          local maxheight = Measure.get_max_height(node:get_value_by_key("maxheight"), node)
+          restricted_by_height = maxheight and maxheight < profile.vehicle_height
+        end
       end
 
       --  make an exception for rising bollard barriers

--- a/osrm-profiles/tram-with-construction.lua
+++ b/osrm-profiles/tram-with-construction.lua
@@ -156,8 +156,10 @@ function process_node(profile, node, result, relations)
       --  check height restriction barriers
       local restricted_by_height = false
       if barrier == 'height_restrictor' then
-         local maxheight = Measure.get_max_height(node:get_value_by_key("maxheight"), node)
-         restricted_by_height = maxheight and maxheight < profile.vehicle_height
+        if maxheight and profile.vehicle_height then
+          local maxheight = Measure.get_max_height(node:get_value_by_key("maxheight"), node)
+          restricted_by_height = maxheight and maxheight < profile.vehicle_height
+        end
       end
 
       --  make an exception for rising bollard barriers

--- a/osrm-profiles/tram.lua
+++ b/osrm-profiles/tram.lua
@@ -155,8 +155,10 @@ function process_node(profile, node, result, relations)
       --  check height restriction barriers
       local restricted_by_height = false
       if barrier == 'height_restrictor' then
-         local maxheight = Measure.get_max_height(node:get_value_by_key("maxheight"), node)
-         restricted_by_height = maxheight and maxheight < profile.vehicle_height
+        if maxheight and profile.vehicle_height then
+          local maxheight = Measure.get_max_height(node:get_value_by_key("maxheight"), node)
+          restricted_by_height = maxheight and maxheight < profile.vehicle_height
+        end
       end
 
       --  make an exception for rising bollard barriers

--- a/osrm-profiles/trambus-with-construction.lua
+++ b/osrm-profiles/trambus-with-construction.lua
@@ -173,8 +173,10 @@ function process_node(profile, node, result, relations)
       --  check height restriction barriers
       local restricted_by_height = false
       if barrier == 'height_restrictor' then
-         local maxheight = Measure.get_max_height(node:get_value_by_key("maxheight"), node)
-         restricted_by_height = maxheight and maxheight < profile.vehicle_height
+        if maxheight and profile.vehicle_height then
+          local maxheight = Measure.get_max_height(node:get_value_by_key("maxheight"), node)
+          restricted_by_height = maxheight and maxheight < profile.vehicle_height
+        end
       end
 
       --  make an exception for rising bollard barriers

--- a/osrm-profiles/trambus.lua
+++ b/osrm-profiles/trambus.lua
@@ -171,8 +171,10 @@ function process_node(profile, node, result, relations)
       --  check height restriction barriers
       local restricted_by_height = false
       if barrier == 'height_restrictor' then
-         local maxheight = Measure.get_max_height(node:get_value_by_key("maxheight"), node)
-         restricted_by_height = maxheight and maxheight < profile.vehicle_height
+        if maxheight and profile.vehicle_height then
+          local maxheight = Measure.get_max_height(node:get_value_by_key("maxheight"), node)
+          restricted_by_height = maxheight and maxheight < profile.vehicle_height
+        end
       end
 
       --  make an exception for rising bollard barriers


### PR DESCRIPTION
Add nil checks to all profiles to fix the current crash loops in our environments.